### PR TITLE
added pygeocoder dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ shodan
 builtwith
 phonenumbers
 google
+pygeocoder


### PR DESCRIPTION
pygeocoder needs to be added to requirements.txt otherwise after running,
`pip3 install -r requirements.txt`
it will error out with this message,
`ModuleNotFoundError: No module named 'pygeocoder'`
After running ,
`pip3 install pygeocoder`
It works properly.